### PR TITLE
Error handling bug 2017.02.24 bhanson

### DIFF
--- a/OneImgixPlugin.php
+++ b/OneImgixPlugin.php
@@ -29,7 +29,7 @@ class OneImgixPlugin extends BasePlugin
      * @return mixed
      */
     public function init()
-    {   
+    {
         require_once __DIR__ . '/vendor/autoload.php';
 
         craft()->on('assets.onReplaceFile', function(Event $event) {
@@ -94,7 +94,7 @@ class OneImgixPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.1.0';
+        return '1.1.1';
     }
 
     /**

--- a/releases.json
+++ b/releases.json
@@ -19,8 +19,8 @@
     },
     {
         "version": "1.1.1",
-        "downloadUrl": "https://github.com/onedesign/oneimgix/archive/v1.1.0.zip",
-        "date": "2017-02-24T21:09:15-06:00",
+        "downloadUrl": "https://github.com/onedesign/oneimgix/archive/v1.1.1.zip",
+        "date": "2017-02-24T21:19:01Z",
         "notes": [
             "[Fixed] Fixed bug where errors were not being properly reported."
         ]

--- a/releases.json
+++ b/releases.json
@@ -16,5 +16,13 @@
             "[Improved] Now uses official [imgix-php](https://github.com/imgix/imgix-php) library for generating URLs.",
             "[Added] Adds `Secure Token` plugin setting that, if used, will generate a secure URL."
         ]
+    },
+    {
+        "version": "1.1.1",
+        "downloadUrl": "https://github.com/onedesign/oneimgix/archive/v1.1.0.zip",
+        "date": "2017-02-24T21:09:15-06:00",
+        "notes": [
+            "[Fixed] Fixed bug where errors were not being properly reported."
+        ]
     }
 ]

--- a/services/OneImgixService.php
+++ b/services/OneImgixService.php
@@ -16,7 +16,7 @@ namespace Craft;
 use Imgix\UrlBuilder;
 
 class OneImgixService extends BaseApplicationComponent
-{   
+{
     protected $settings;
 
     public function __construct()
@@ -97,8 +97,9 @@ class OneImgixService extends BaseApplicationComponent
 
             $response = $request->send();
         } catch (\Guzzle\Http\Exception\ClientErrorResponseException $exception) {
+            $statusCode = $exception->getResponse()->getStatusCode();
             $responseBody = $exception->getResponse()->getBody(true);
-            OneImgixPlugin::log('Imgix purge request returned a non-successful response: ' . $statusCode, LogLevel::Error, true);
+            OneImgixPlugin::log(sprintf('Imgix purge request returned a non-successful response: [%s] %s', $statusCode, $responseBody), LogLevel::Error, true);
             return false;
         }
 


### PR DESCRIPTION
Fixes a bug where non-successfull calls to imgix were blowing up since `$statusCode` wasn't defined.

To test, try to upload an asset when the Imgix Base URL doesn't match your asset source's URL. If you check out the network tab, you'll notice a 500 error being thrown when Craft tries to upload the asset because `$statusCode` isn't defined within our `catch` statement.